### PR TITLE
Ignore auto generated tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swn
 *.pyc
 docs/_build/*
+doc/tags


### PR DESCRIPTION
If you use this plugin as a submodule with pathogen or whatever this file is generated and then shows up as an unstaged commit