### PR TITLE
Add support for the autopep8 experimental flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -121,6 +121,13 @@ Chose diff window type. (default: horizontal)
 
  let g:autopep8_diff_type='vertical'
 
+Enable/disable autopep8 experimental support (default: disabled)
+
+::
+
+ let g:autopep8_experimental=1
+ let g:autopep8_experimental=0
+
 
 Automatically format every time saving a file.
 

--- a/doc/autopep8.txt
+++ b/doc/autopep8.txt
@@ -111,6 +111,12 @@ Chose diff window type. (default: horizontal)
  let g:autopep8_diff_type='vertical'
 <
 
+Enable/disable autopep8 experimental support (default: disabled)
+>
+ let g:autopep8_experimental=1
+ let g:autopep8_experimental=0
+<
+
 Automatically format every time saving a file.
 
 ::

--- a/ftplugin/python_autopep8.vim
+++ b/ftplugin/python_autopep8.vim
@@ -84,13 +84,19 @@ if !exists("*Autopep8(...)")
             let autopep8_indent_size=""
         endif
 
+        if exists("g:autopep8_experimental") && (g:autopep8_experimental)
+            let autopep8_experimental=" --experimental"
+        else
+            let autopep8_experimental=""
+        endif
+
         if exists("g:autopep8_diff_type") && g:autopep8_diff_type == "vertical"
             let autopep8_diff_type="vertical"
         else
             let autopep8_diff_type="horizontal"
         endif
 
-        let execmdline=autopep8_cmd.autopep8_pep8_passes.autopep8_selects.autopep8_ignores.autopep8_max_line_length.autopep8_aggressive.autopep8_indent_size.autopep8_range
+        let execmdline=autopep8_cmd.autopep8_pep8_passes.autopep8_selects.autopep8_ignores.autopep8_max_line_length.autopep8_aggressive.autopep8_indent_size.autopep8_range.autopep8_experimental
 
         " current cursor
         " show diff if not explicitly disabled


### PR DESCRIPTION
From the autopep8 readme:

> Passing in ``--experimental`` enables the following functionality:
>
> - Shortens code lines by taking its length into account